### PR TITLE
New transcript fix

### DIFF
--- a/hx_util/GetExcelLinks.py
+++ b/hx_util/GetExcelLinks.py
@@ -162,7 +162,12 @@ def getLinks(filename, args, dirpath):
         complete_links.extend(links_with_urls)
 
     # Text is ALSO stored in a different file, but it's the same one for every sheet.
-    string_data = archive.read('xl/sharedStrings.xml')
+    try:
+        string_data = archive.read('xl/sharedStrings.xml')
+    except KeyError:
+        # If that file doesn't exist, just skip it and move on.
+        return complete_links
+
     string_soup = BeautifulSoup(string_data, 'xml')
     complete_links = getLinkText(string_soup, complete_links)
 
@@ -242,8 +247,10 @@ def getExcelLinks(args):
             # Make sure this is an Excel file (just check extension)
             if name.lower().endswith('.xlsx'):
                 # Get the links from that file.
-                linklist.extend(getLinks(name, args, False))
-                filecount += 1
+                newlinks = getLinks(name, args, False)
+                if(newlinks != []):
+                    linklist.extend()
+                    filecount += 1
 
         # If it's a directory:
         if os.path.isdir(name):

--- a/hx_util/HXLiveTools.py
+++ b/hx_util/HXLiveTools.py
@@ -14,7 +14,7 @@ from hx_util import SrtRename
 # Calls multiple scripts to help with the archive process for HarvardX courses.
 # Passes all arguments through to the scripts, but you probably don't want to.
 #
-# Last update: June 6th 2018
+# Last update: Sept 26th 2018
 ######################################
 
 def runLiveTools(args):
@@ -24,7 +24,7 @@ def runLiveTools(args):
     json2srt.json2srt(args + ['-r'])
     # Rename (copy) the SRT files to match our upload names and make a zip file.
     # Put this in the course folder.
-    SrtRename.SrtRename(args + ['-n', '-z', '-i', 'Course_Video_Sheet.tsv', '-o', 'Course_SRT_Files.zip'])
+    SrtRename.SrtRename(args + ['-c', '-n', '-z', '-i', 'Course_Video_Sheet.tsv', '-o', 'Course_SRT_Files.zip'])
     # Make the link spreadsheet.
     Make_Course_Sheet.Make_Course_Sheet(args + ['-links', '-o', 'Course_Link_Sheet.tsv'])
     # Make the image spreadsheet.

--- a/hx_util/Make_Course_Sheet.py
+++ b/hx_util/Make_Course_Sheet.py
@@ -49,7 +49,7 @@ You can specify the following options:
 
 This script may fail on courses with empty containers.
 
-Last update: June 14th, 2018
+Last update: September 26th, 2018
 """
 
 
@@ -318,10 +318,23 @@ def getComponentInfo(folder, filename, child, args):
 
     # get video information
     if root.tag == 'video' and args.video:
+
+        temp['sub'] = 'No subtitles found.'
+
+        # Old-style course exports have non-blank 'sub' attributes.
         if 'sub' in root.attrib:
-            temp['sub'] = 'subs_' + root.attrib['sub'] + '.srt.sjson'
-        else:
-            temp['sub'] = 'No subtitles found.'
+            if root.attrib['sub'] != '':
+                temp['sub'] = 'subs_' + root.attrib['sub'] + '.srt.sjson'
+
+        # New-style course exports (Aug 15 2018) have a different hierarchy.
+        for va in root.iter('video_asset'):
+            for trs in va.iter('transcripts'):
+                for transcript in trs.iter('transcript'):
+                    if transcript.attrib['language_code'] == 'en':
+                        temp['sub'] = root.attrib['edx_video_id'] + '-en.srt'
+                        break
+                    else:
+                        temp['sub'] = 'No English subtitles found.'
 
         if 'youtube_id_1_0' in root.attrib:
             temp['youtube'] = root.attrib['youtube_id_1_0']

--- a/hx_util/SrtRename.py
+++ b/hx_util/SrtRename.py
@@ -21,7 +21,7 @@ Valid options:
   -i Open a specific named .tsv file using the following argument.
   -o Name the zip file using the following argument. Only works with -z.
 
-Last update: March 15th 2018
+Last update: September 26th 2018
 """
 
 # Make a dictionary that shows which srt files match which original upload names
@@ -31,7 +31,10 @@ def getOriginalNames(course_folder, args):
 
     # Find our course tsv file. It's based on the course's display_name,
     # or set by an input filename argument.
-    tree = ET.parse(os.path.join(course_folder, 'course/course.xml'))
+    outer_tree = ET.parse(os.path.join(course_folder, 'course.xml'))
+    outer_root = outer_tree.getroot()
+    course_file_path = os.path.join(course_folder, 'course', outer_root.attrib['url_name'] + '.xml')
+    tree = ET.parse(course_file_path)
     root = tree.getroot()
     course_title = root.attrib['display_name']
     course_outline_file = args.i if args.i else course_title + '.tsv'
@@ -70,7 +73,7 @@ def setNewNames(course_folder, nameDict, args, course_title):
     filecount = 0
 
     for srt in nameDict:
-        # Strip off the .sjson extension since we're renaming only SRTs.
+        # Strip off the .sjson extension (if any) since we're renaming only SRTs.
         oldname = os.path.join(static_folder, srt.replace('.sjson',''))
         # Add .mp4 to the upload filenames because they're videos
         newname = os.path.join(target_folder, nameDict[srt] + '.srt')

--- a/hx_util/__init__.py
+++ b/hx_util/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Colin Fredericks'
 __email__ = 'colin_frederecks'
-__version__ = '0.2.4'
+__version__ = '0.2.5'

--- a/hx_util/json2srt.py
+++ b/hx_util/json2srt.py
@@ -10,13 +10,14 @@ To use:
 python3 sjson2srt.py file_or_directory (options)
 
 Creates a new .srt file for every .srt.sjson file found.
+If it's a new-style export and there are no .sjson files, move on gracefully.
 
 Valid options:
   -o Overwrite. Deletes the .srt.sjson file after it has been converted.
   -r Recursive. Works on .srt.sjson files in subdirectories as well.
   -h Help. Print this message.
 
-Last update: March 15th 2018
+Last update: September 26th 2018
 """
 
 # Split long lines on a space near the middle.


### PR DESCRIPTION
EdX's XML for video transcripts changed on August 15th. This is the fix to handle the new XML style. Their "documentation" of this is at https://openedx.atlassian.net/wiki/spaces/EDUCATOR/pages/815366180/Content-store+Deprecation+Summary