### PR TITLE
catch LTI tags

### DIFF
--- a/hx_util/Make_Course_Sheet.py
+++ b/hx_util/Make_Course_Sheet.py
@@ -50,7 +50,7 @@ You can specify the following options:
 
 This script may fail on courses with empty containers.
 
-Last update: April 3rd 2019
+Last update: July 15th 2021
 """
 
 
@@ -60,7 +60,6 @@ Last update: April 3rd 2019
 skip_tags = [
     "annotatable",  # This is the older, deprecated annotation component.
     "google-document",
-    "lti",  # This is the older, deprecated LTI component.
     "oppia",
     "openassessment",  # This is the older, deprecated ORA.
     "poll_question",  # This is the older, deprecated poll component.
@@ -478,7 +477,7 @@ def getXMLInfo(folder, root, args):
         "html",
         "imageannotation",
         "library_content",
-        "lti_consumer",
+        "lti",
         "pb-dashboard",  # This is currently unique to HarvardX DataWise
         "poll",
         "problem",

--- a/hx_util/__init__.py
+++ b/hx_util/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = "Colin Fredericks"
 __email__ = "colin_frederecks"
-__version__ = "1.1.0"  # update version lxml dependency
+__version__ = "1.1.1"  # catch LTI tags


### PR DESCRIPTION
The previous version was looking for the wrong tag name for LTI tags.